### PR TITLE
Fix parsing requirement version when inline comment exists

### DIFF
--- a/pypiup/requirement.py
+++ b/pypiup/requirement.py
@@ -27,7 +27,8 @@ class Requirement(object):
         regex = re.split("==", requirement)
         try:
             self.name = regex[0]
-            self.current_version = regex[1]
+            # Ignore inline comments if any
+            self.current_version = regex[1].split("#")[0].rstrip()
             self.get_package_info()
             self.compare()
         except IndexError:

--- a/requirements/requirements-tests.txt
+++ b/requirements/requirements-tests.txt
@@ -1,6 +1,6 @@
 Django==1.7.1
 djangorestframework==3.3.2
-drfdocs==0.0.4
+drfdocs==0.0.4               # via somelib
 
 # commented-package==1.2.3
 testing-errors-abc==0.0.12


### PR DESCRIPTION
Hi,

I'm using *pypiup* with *pip-tools* in my projects. *pip-tools* compiles `requirements.txt` and automatically fills dependencies as inline comments:

```
#
# This file is autogenerated by pip-compile
# To update, run:
#
#    pip-compile --output-file requirements-dev.txt requirements-dev.in
#
appnope==0.1.0            # via ipython
astroid==1.5.3            # via pylint
certifi==2017.4.17        # via requests
chardet==3.0.3            # via requests
click==6.7                # via pip-tools, pypiup
decorator==4.0.11         # via ipython, traitlets
first==2.0.1              # via pip-tools
flake8==3.3.0
idna==2.5                 # via requests
```

Unfortunately *pypiup==0.0.2* fails to compare such kind of lines with the following result:

```
✗ appnope
  Could not compare. Invalid semver, From 0.1.0            # via ipython to 0.1.0.

✗ astroid
  Could not compare. Invalid semver, From 1.5.3            # via pylint to 1.5.3.

✗ certifi
  Could not compare. Invalid semver, From 2017.4.17        # via requests to 2017.4.17.

✗ chardet
  Could not compare. Invalid semver, From 3.0.3            # via requests to 3.0.4.

✗ click
  Could not compare. Invalid semver, From 6.7                # via pip-tools, pypiup to 6.7.

✗ decorator
  Could not compare. Invalid semver, From 4.0.11         # via ipython, traitlets to 4.0.11.

✗ first
  Could not compare. Invalid semver, From 2.0.1              # via pip-tools to 2.0.1.

✓ flake8
  Up to date, 3.3.0.

✗ idna
  Could not compare. Invalid semver, From 2.5                 # via requests to 2.5.
```

This PR fixes requirement version parsing making it possible to combine *pypiup* with *pip-tools* in the projects.